### PR TITLE
Runs sync for all service types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ This takes about 10 minutes for initial setup, after that things run smoothly wi
 - You'll then need to setup a Planning Center [developer account](https://developer.planning.center/docs/#/introduction).
   - Create a new **Personal Access Token**
   - Note your `Application Id` and `Secret`
-- To get your Service Id, you'll want to:
-  - Go to your Planning Center Dashboard
-  - Click gear to the top right of your serivce and select `Settings`
-  - Your `Service ID` will be at the end of the url
-    - ie: if the url is `https://services.planningcenteronline.com/service_types/1000` your Service ID is `1000`
 - Then head over to Spotify and create an [application](https://developer.spotify.com/documentation/general/guides/app-settings/#register-your-app)
   - Create a new application
   - You are not creating a commercial integration
@@ -32,13 +27,12 @@ Running the script is as simple as running `./sync` from the root directory of t
 
 ### For the first time:
 
-Running this for the first time will take a few extra seconds of setup, as we'll need to enter the five values we generated in Step 2.
+Running this for the first time will take a few extra seconds of setup, as we'll need to enter the four values we generated in Step 2.
 
 Those values are:
   - Planning Center:
     - `Application Id`
     - `Secret Key`
-    - `Service Id`
   - Spotify
     - `Client ID`
     - `Client Secret`

--- a/app/Models/Credentials.php
+++ b/app/Models/Credentials.php
@@ -43,7 +43,6 @@ class Credentials
         $defaultCredentials = [
             'PLANNING_CENTER_APPLICATION_ID' => '',
             'PLANNING_CENTER_SECRET' => '',
-            'PLANNING_CENTER_SERVICE_TYPE_ID' => '',
             'SPOTIFY_CLIENT_ID' => '',
             'SPOTIFY_CLIENT_SECRET' => '',
         ];

--- a/app/Models/PlanningCenter/PlanningCenter.php
+++ b/app/Models/PlanningCenter/PlanningCenter.php
@@ -3,15 +3,9 @@
 namespace App\Models\PlanningCenter;
 
 use App\Models\Api;
-use DateTimeImmutable;
 
 class PlanningCenter
 {
-    /**
-     * int The number of future services to sync on a given run.
-     */
-    const NUM_SERVICES = 4;
-
     /**
      * An instance of the API object used to connect to Planning Center.
      *
@@ -34,23 +28,14 @@ class PlanningCenter
     private $secretKey;
 
     /**
-     * The id of your service type in Planning Center.
-     *
-     * @var int
-     */
-    private $serviceTypeId;
-
-    /**
      * @param string $applicationId
      * @param string $secretKey
-     * @param int $serviceTypeId
      * @param Api $api
      */
-    public function __construct(string $applicationId, string $secretKey, int $serviceTypeId, Api $api)
+    public function __construct(string $applicationId, string $secretKey, Api $api)
     {
         $this->applicationId = $applicationId;
         $this->secretKey = $secretKey;
-        $this->serviceTypeId = $serviceTypeId;
         $this->api = $api;
 
         $authorization = base64_encode("{$applicationId}:{$secretKey}");
@@ -59,25 +44,19 @@ class PlanningCenter
     }
 
     /**
-     * Returns upcoming ServicePlans.
-     *
-     * @param DateTimeImmutable $servicesAfterDate Returns services after this date
+     * Returns the ServiceTypes.
      *
      * @return array
      */
-    public function getServicePlansAfter(DateTimeImmutable $servicesAfterDate): array
+    public function getServiceTypes(): array
     {
-        $after = $servicesAfterDate->format('Y-m-d');
-        $numServices = self::NUM_SERVICES;
-        $serviceTypeId = $this->serviceTypeId;
-
-        $services = $this->api->request(
+        $serviceTypes = $this->api->request(
             'GET',
-            "service_types/{$this->serviceTypeId}/plans?filter=after&after={$after}&per_page={$numServices}"
+            'service_types'
         )->data;
 
-        return array_map(function ($service) use ($serviceTypeId) {
-            return new ServicePlan($serviceTypeId, $service, $this->api);
-        }, $services);
+        return array_map(function ($serviceType) {
+            return new ServiceType($serviceType, $this->api);
+        }, $serviceTypes);
     }
 }

--- a/app/Models/PlanningCenter/ServiceType.php
+++ b/app/Models/PlanningCenter/ServiceType.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models\PlanningCenter;
+
+use App\Models\Api;
+use App\Models\Spotify\Spotify;
+use DateTimeImmutable;
+
+class ServiceType
+{
+    /**
+     * int The number of future services to sync on a given run.
+     */
+    const NUM_SERVICES = 4;
+
+    /**
+     * @var Api
+     */
+    protected $api;
+
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * Handles the API response from Planning Center and creates a new object.
+     *
+     * @param object $serviceType
+     * @param Api $api
+     */
+    public function __construct(object $serviceType, Api $api)
+    {
+        $this->id = $serviceType->id;
+        $this->api = $api;
+    }
+
+    /**
+     * Syncs upcoming ServicePlans with Spotify.
+     *
+     * @param Spotify $spotify
+     */
+    public function syncServicePlansWithSpotify(Spotify $spotify): void
+    {
+        $today = new DateTimeImmutable();
+        $servicePlans = $this->getServicePlansAfter($today, self::NUM_SERVICES);
+
+        foreach ($servicePlans as $servicePlan) {
+            $servicePlan->syncWithSpotify($spotify);
+        }
+    }
+
+    /**
+     * Returns upcoming ServicePlans.
+     *
+     * @param DateTimeImmutable $servicesAfterDate Returns services after this date
+     *
+     * @return array
+     */
+    protected function getServicePlansAfter(DateTimeImmutable $servicesAfterDate, int $numServices): array
+    {
+        $after = $servicesAfterDate->format('Y-m-d');
+
+        $services = $this->api->request(
+            'GET',
+            "service_types/{$this->id}/plans?filter=after&after={$after}&per_page={$numServices}"
+        )->data;
+
+        return array_map(function ($service) {
+            return new ServicePlan($this->id, $service, $this->api);
+        }, $services);
+    }
+}

--- a/app/sync.php
+++ b/app/sync.php
@@ -9,7 +9,6 @@ use App\Models\Credentials;
 use App\Models\PlanningCenter\PlanningCenter;
 use App\Models\Spotify\Spotify;
 use App\Models\Spotify\SpotifyAuthorization;
-use DateTimeImmutable;
 
 // Setup initial authorization
 $credentialsFile = __DIR__.'/../storage/auth.json';
@@ -40,13 +39,11 @@ $spotify = new Spotify(
 $planningCenter = new PlanningCenter(
     $credentials->get('PLANNING_CENTER_APPLICATION_ID'),
     $credentials->get('PLANNING_CENTER_SECRET'),
-    $credentials->get('PLANNING_CENTER_SERVICE_TYPE_ID'),
     new Api()
 );
 
-$today = new DateTimeImmutable();
-$services = $planningCenter->getServicePlansAfter($today);
+$serviceTypes = $planningCenter->getServiceTypes();
 
-foreach ($services as $service) {
-    $service->syncWithSpotify($spotify);
+foreach ($serviceTypes as $serviceType) {
+    $serviceType->syncServicePlansWithSpotify($spotify);
 }


### PR DESCRIPTION
Removes the need to specify a `SERVICE_TYPE_ID` as we'll sync the next 4 services for all service types in the user's account.